### PR TITLE
fix: TRIVY_JAVA_DB_REPOSTITORY typo

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-      TRIVY_JAVA_DB_REPOSTITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
+      TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Var name had extra T. Trivy not read it. Java DB skipped mirror list, fell back to default registry. TRIVY_DB_REPOSITORY was fine, so only Java DB hit.

Rename to TRIVY_JAVA_DB_REPOSITORY. Values unchanged.